### PR TITLE
Readme tf-0.12 related and makefile git-release updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: help
 SHELL := /bin/bash
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_SSH_DIR := ~/.ssh
+LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
 
 TF_PWD_DIR := $(shell pwd)
 TF_VER := 0.11.14
@@ -13,6 +16,20 @@ docker run --rm \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER}
 endef
+
+# pre-req -> https://github.com/pnikosis/semtag
+define GIT_SEMTAG_CMD_PREFIX
+docker run --rm \
+-v ${TF_PWD_DIR}:/data:rw \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+--entrypoint=/opt/semtag/semtag/semtag \
+-it binbash/git-release
+endef
+
+GIT_SEMTAG_VER_PATCH := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s patch -o)
+GIT_SEMTAG_VER_MINOR := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s minor -o)
+GIT_SEMTAG_VER_MINOR := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s major -o)
 
 help:
 	@echo 'Available Commands:'
@@ -31,3 +48,45 @@ doc: ## doc: A utility to generate documentation from Terraform modules in vario
 
 lint: ## lint: TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan.
 	docker run --rm -v ${TF_PWD_DIR}:/data -t wata727/tflint --deep
+
+release-patch: ## releasing patch (eg: 0.0.1 -> 0.0.2) based on semantic tagging script for Git
+	# pre-req -> https://github.com/pnikosis/semtag
+	${GIT_SEMTAG_CMD_PREFIX} get
+	${GIT_SEMTAG_CMD_PREFIX} final -s patch
+
+release-minor: ## releasing minor (eg: 0.0.2 -> 0.1.0) based on semantic tagging script for Git
+	# pre-req -> https://github.com/pnikosis/semtag
+	${GIT_SEMTAG_CMD_PREFIX} get
+	${GIT_SEMTAG_CMD_PREFIX} final -s minor
+
+release-major: ## releasing major (eg: 0.1.0 -> 1.0.0) based on semantic tagging script for Git
+	# pre-req -> https://github.com/pnikosis/semtag
+	${GIT_SEMTAG_CMD_PREFIX} get
+	${GIT_SEMTAG_CMD_PREFIX} final -s major
+
+changelog-init: ## git-chglog (https://github.com/git-chglog/git-chglog) config initialization -> ./.chglog
+	@if [ ! -d ./.chglog ]; then\
+		docker run --rm -v ${TF_PWD_DIR}:/data -it binbash/git-release --init;\
+		sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog;\
+	else\
+		  echo "==============================";\
+    	echo "git-chglog already initialized";\
+    	echo "==============================";\
+    	echo "$$(ls ./.chglog)";\
+    	echo "==============================";\
+	fi
+
+changelog-patch: ## git-chglog generation for path release
+	docker run --rm -v ${TF_PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER_PATCH}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md
+
+changelog-minor: ## git-chglog generation for minor release
+	docker run --rm -v ${TF_PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER_MINOR}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md
+
+changelog-major: ## git-chglog generation for major release
+	docker run --rm -v ${TF_PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER_MAJOR}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ creation (or use a pre-existing one) to alert when a U$S (currency actually conf
 Provides an AWS budget resource (`aws_budgets_budget`). Budgets use the cost visualisation provided by **Cost Explorer** to show
 you the status of your budgets, to provide forecasts of your estimated costs, and to track your AWS usage, including your free tier usage.
 
+## Releases
+- **Versions:** `<= 0.x.y` (Terraform 0.11.x compatible)
+    - eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/0.0.1
+
+- **Versions:** `>= 1.x.y` (Terraform 0.12.x compatible -> **WIP**)
+    - eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/1.0.0
+
 ---
 
 ## Inputs


### PR DESCRIPTION
## Updating <img src="https://avatars1.githubusercontent.com/u/31255874?s=280&v=4" alt="binbash" width="40"/> terraform-aws-cost-billing-alarm repo:

<div align="middle">
  <img src="http://automationtoolsbootcamp.com/images/terraform.png" alt="terraform" width="150"/>
  <img src="https://pbs.twimg.com/profile_images/907881675304181760/_ftIQb3v_400x400.jpg" alt="aws" width="150"/>
</div>

###  :notebook: Summary 
1. Updating README.md with tf 0.12 release info
```
Releases
Versions: <= 0.x.y (Terraform 0.11.x compatible)

eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/0.0.1
Versions: >= 1.x.y (Terraform 0.12.x compatible -> WIP)

eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/1.0.0
```  
2. Adding `Makefile` to follow the new standard dockerized git-release cross-project modules approach release tagging.
Since the need of generating consistent cross-project versioning tagging we've decided to automate this task in our Makefiles.
Ref: https://github.com/binbashar/public-docker-images/pull/10

### :man_technologist:  New Commits 
- Readme tf-0.12 related and makefile git-release updates

### :triangular_flag_on_post:  Post Tasks
- Update release tag `0.0.2` after PR merged to master in order to reflect the updates at the Terraform Registry -> https://registry.terraform.io/modules/binbashar/cost-budget/aws/0.0.1.  

### :1st_place_medal:  TODO
- Add `terratest` to this module.
- Add new version `1.0.0` with tf-0.12 support.