### PR TITLE
Bbl 122 terratests circleci job

### DIFF
--- a/.circleci/aws_config
+++ b/.circleci/aws_config
@@ -1,0 +1,7 @@
+[default]
+region = us-east-1
+output = json
+
+[bb-dev-deploymaster]
+role_arn = arn:aws:iam::523857393444:role/DeployMaster
+source_profile = default

--- a/.circleci/aws_config
+++ b/.circleci/aws_config
@@ -1,7 +1,0 @@
-[default]
-region = us-east-1
-output = json
-
-[bb-dev-deploymaster]
-role_arn = arn:aws:iam::523857393444:role/DeployMaster
-source_profile = default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,13 @@ jobs:
 
       - run: pwd
       - run: ls -ltra
+      - run: find / -name 'aws'
       - run: git branch
 
       - run:
           name: test1-terraform-format
           command: |
-            if [[ make format ]]; then
+            if [[ $(make format| tail -n +2) ]]; then
               echo "==================================================================================================="
               echo " NOT PASSED - There are Terraform conf files that needs a canonical format and styleto be formated "
               echo "==================================================================================================="
@@ -64,6 +65,7 @@ jobs:
       - run:
           name: Configure awscli
           command: |
+            echo "AWS_ACCESS_KEY_ID - $AWS_ACCESS_KEY_ID"
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile $AWS_PROFILE_NAME
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile $AWS_PROFILE_NAME
             aws iam get-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ jobs:
             aws configure set role_arn arn:aws:iam::$AWS_ACCOUNT_ID_DEV:role/DeployMaster --profile $AWS_PROFILE_NAME
             aws configure set source_profile default --profile $AWS_PROFILE_NAME
 
-      - run: find . -name 'aws_config'
-      - run: find . -name '.aws'
+      - run: cat ~/.aws/credentials
+      - run: cat ~/.aws/config
 
       - run:
           name: Test AWS permissions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ jobs:
             aws configure set role_arn arn:aws:iam::$AWS_ACCOUNT_ID_DEV:role/DeployMaster --profile $AWS_PROFILE_NAME
             aws configure set source_profile default --profile $AWS_PROFILE_NAME
 
-      - run: cat ~/.aws/credentials
-      - run: cat ~/.aws/config
+#      - run: cat ~/.aws/credentials
+#      - run: cat ~/.aws/config
 
       - run:
           name: Test AWS permissions
@@ -86,7 +86,8 @@ jobs:
 
       - run:
           name: test3-terratests
-          command: make terratest-go-test
+          command: |
+            make terratest-dep-init && make terratest-go-test
   #
   # Release
   #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,13 @@ jobs:
           command: aws budgets describe-budgets --account-id $AWS_ACCOUNT_ID_DEV --profile $AWS_PROFILE_NAME
 
       - run:
-          name: test3-terratests
-          command: |
-            make terratest-dep-init && make terratest-go-test
+          name: test3-terratests-dep-init
+          command: make terratest-dep-init
+
+      - run:
+          name: test3-terratests-go-test
+          command: make terratest-go-test
+
   #
   # Release
   #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,9 @@ jobs:
       - run:
           name: Configure awscli
           command: |
-          aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile $AWS_PROFILE_NAME
-          aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile $AWS_PROFILE_NAME
-          aws iam get-user
+            aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile $AWS_PROFILE_NAME
+            aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile $AWS_PROFILE_NAME
+            aws iam get-user
 
       - run:
           name: Test AWS permissions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
 
       - run: pwd
       - run: ls -ltra
-      - run: find / -name 'aws'
       - run: git branch
 
       - run:
@@ -61,6 +60,8 @@ jobs:
       - run:
           name: Install awscli
           command: sudo pip install awscli
+
+      - run: find . -name 'aws_config'
 
       - run:
           name: Configure awscli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,12 +67,18 @@ jobs:
             echo "AWS_ACCESS_KEY_ID - $AWS_ACCESS_KEY_ID"
             echo "AWS_PROFILE_NAME - $AWS_PROFILE_NAME"
 
+            # AWS defautl awscli profile
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
-#            aws configure --profile $AWS_PROFILE_NAME --aws_access_key_id $AWS_ACCESS_KEY_ID --aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+            aws configure set region us-east-1
+            aws configure set output json
+
+            # AWS dev awscli profile
+            aws configure set role_arn arn:aws:iam::$AWS_ACCOUNT_ID_DEV:role/DeployMaster --profile $AWS_PROFILE_NAME
+            aws configure set source_profile default --profile $AWS_PROFILE_NAME
 
       - run: find . -name 'aws_config'
-      - run: find . -name 'credentials'
+      - run: find . -name '.aws'
 
       - run:
           name: Test AWS permissions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,6 @@ jobs:
 
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile $AWS_PROFILE_NAME
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile $AWS_PROFILE_NAME
-            aws iam get-user
 
       - run:
           name: Test AWS permissions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ workflows:
       - test-e2e-terratests:
           context: binbashar-org-global-context
       - release-patch-with-changelog:
+          context: binbashar-org-global-context
           filters:
             branches:
              only: # only branches matching the below regex filters will run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,91 @@
 version: 2.1
 
 jobs:
+  #
+  # Test 1 & Test 2
+  #
+  test-static-code-and-linting:
+  machine:
+    image: ubuntu-1604:201903-01
+    docker_layer_caching: true
+
+  steps:
+    - checkout
+
+    - add_ssh_keys:
+        fingerprints:
+          - "f5:ca:b0:c5:06:26:aa:ec:c8:a7:75:57:f0:e7:c2:f3"
+
+    - run: pwd
+    - run: ls -ltra
+    - run: git branch
+
+    - run:
+        name: test1-terraform-format
+        command: |
+          if [[ make format ]]; then
+            echo "==================================================================================================="
+            echo " NOT PASSED - There are Terraform conf files that needs a canonical format and styleto be formated "
+            echo "==================================================================================================="
+            exit 1
+          else
+            echo "==================================================================================================="
+            echo " PASSED - All Terraform conf files already have canonical format and are correcyly styled          "
+            echo "==================================================================================================="
+          fi
+
+      - run:
+          name: test2-terraform-linting
+          command: |
+            if make lint | grep 'Awesome! Your code is following the best practices'; then
+              echo "==============================================================================================="
+              echo " PASSED - Awesome! Your code is following the best practices                                   "
+              echo "==============================================================================================="
+            else
+              echo "==============================================================================================="
+              echo " NOT PASSED - Terraform lint needed                                                            "
+              echo "==============================================================================================="
+            fi
+  #
+  # Test 3
+  #
+  test-e2e-terratests:
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
+
+    steps:
+      - checkout
+
+      - add_ssh_keys:
+          fingerprints:
+            - "f5:ca:b0:c5:06:26:aa:ec:c8:a7:75:57:f0:e7:c2:f3"
+
+      - run: pwd
+      - run: ls -ltra
+      - run: git branch
+
+      - run:
+          name: Install awscli
+          command: sudo pip install awscli
+
+      - run:
+          name: Configure awscli
+          command: |
+          aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile $AWS_PROFILE_NAME
+          aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile $AWS_PROFILE_NAME
+          aws iam get-user
+
+     - run:
+          name: Test AWS permissions
+          command: aws budgets describe-budgets --account-id $AWS_ACCOUNT_ID_DEV --profile $AWS_PROFILE_NAME
+
+      - run:
+          name: test3-terratests
+          command: make terratest-go-test
+  #
+  # Release
+  #
   release-patch-with-changelog:
     machine:
       image: ubuntu-1604:201903-01
@@ -14,9 +99,7 @@ jobs:
             - "f5:ca:b0:c5:06:26:aa:ec:c8:a7:75:57:f0:e7:c2:f3"
 
       - run: pwd
-
       - run: ls -ltra
-
       - run: git branch
 
       - run:
@@ -36,11 +119,15 @@ jobs:
               echo "$(git status)"
               echo "==============================================================================================="
             fi
-
+#
+# Jobs workflow
+#
 workflows:
   version: 2
   changelog_and_release:
     jobs:
+      - test-static-code-and-linting
+      - test-e2e-terratests
       - release-patch-with-changelog:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,47 +5,47 @@ jobs:
   # Test 1 & Test 2
   #
   test-static-code-and-linting:
-  machine:
-    image: ubuntu-1604:201903-01
-    docker_layer_caching: true
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
 
-  steps:
-    - checkout
+    steps:
+      - checkout
 
-    - add_ssh_keys:
-        fingerprints:
-          - "f5:ca:b0:c5:06:26:aa:ec:c8:a7:75:57:f0:e7:c2:f3"
+      - add_ssh_keys:
+          fingerprints:
+            - "f5:ca:b0:c5:06:26:aa:ec:c8:a7:75:57:f0:e7:c2:f3"
 
-    - run: pwd
-    - run: ls -ltra
-    - run: git branch
-
-    - run:
-        name: test1-terraform-format
-        command: |
-          if [[ make format ]]; then
-            echo "==================================================================================================="
-            echo " NOT PASSED - There are Terraform conf files that needs a canonical format and styleto be formated "
-            echo "==================================================================================================="
-            exit 1
-          else
-            echo "==================================================================================================="
-            echo " PASSED - All Terraform conf files already have canonical format and are correcyly styled          "
-            echo "==================================================================================================="
-          fi
+      - run: pwd
+      - run: ls -ltra
+      - run: git branch
 
       - run:
-          name: test2-terraform-linting
+          name: test1-terraform-format
           command: |
-            if make lint | grep 'Awesome! Your code is following the best practices'; then
-              echo "==============================================================================================="
-              echo " PASSED - Awesome! Your code is following the best practices                                   "
-              echo "==============================================================================================="
+            if [[ make format ]]; then
+              echo "==================================================================================================="
+              echo " NOT PASSED - There are Terraform conf files that needs a canonical format and styleto be formated "
+              echo "==================================================================================================="
+              exit 1
             else
-              echo "==============================================================================================="
-              echo " NOT PASSED - Terraform lint needed                                                            "
-              echo "==============================================================================================="
+              echo "==================================================================================================="
+              echo " PASSED - All Terraform conf files already have canonical format and are correcyly styled          "
+              echo "==================================================================================================="
             fi
+
+        - run:
+            name: test2-terraform-linting
+            command: |
+              if make lint | grep 'Awesome! Your code is following the best practices'; then
+                echo "==============================================================================================="
+                echo " PASSED - Awesome! Your code is following the best practices                                   "
+                echo "==============================================================================================="
+              else
+                echo "==============================================================================================="
+                echo " NOT PASSED - Terraform lint needed                                                            "
+                echo "==============================================================================================="
+              fi
   #
   # Test 3
   #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,16 +61,18 @@ jobs:
           name: Install awscli
           command: sudo pip install awscli
 
-      - run: find . -name 'aws_config'
-
       - run:
           name: Configure awscli
           command: |
             echo "AWS_ACCESS_KEY_ID - $AWS_ACCESS_KEY_ID"
-            echo "$AWS_PROFILE_NAME - $AWS_PROFILE_NAME"
+            echo "AWS_PROFILE_NAME - $AWS_PROFILE_NAME"
 
-            aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile $AWS_PROFILE_NAME
-            aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile $AWS_PROFILE_NAME
+            aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+            aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+#            aws configure --profile $AWS_PROFILE_NAME --aws_access_key_id $AWS_ACCESS_KEY_ID --aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+
+      - run: find . -name 'aws_config'
+      - run: find . -name 'credentials'
 
       - run:
           name: Test AWS permissions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,6 @@ jobs:
     steps:
       - checkout
 
-      - add_ssh_keys:
-          fingerprints:
-            - "f5:ca:b0:c5:06:26:aa:ec:c8:a7:75:57:f0:e7:c2:f3"
-
       - run: pwd
       - run: ls -ltra
       - run: git branch
@@ -34,18 +30,18 @@ jobs:
               echo "==================================================================================================="
             fi
 
-        - run:
-            name: test2-terraform-linting
-            command: |
-              if make lint | grep 'Awesome! Your code is following the best practices'; then
-                echo "==============================================================================================="
-                echo " PASSED - Awesome! Your code is following the best practices                                   "
-                echo "==============================================================================================="
-              else
-                echo "==============================================================================================="
-                echo " NOT PASSED - Terraform lint needed                                                            "
-                echo "==============================================================================================="
-              fi
+      - run:
+          name: test2-terraform-linting
+          command: |
+            if make lint | grep 'Awesome! Your code is following the best practices'; then
+              echo "==============================================================================================="
+              echo " PASSED - Awesome! Your code is following the best practices                                   "
+              echo "==============================================================================================="
+            else
+              echo "==============================================================================================="
+              echo " NOT PASSED - Terraform lint needed                                                            "
+              echo "==============================================================================================="
+            fi
   #
   # Test 3
   #
@@ -56,10 +52,6 @@ jobs:
 
     steps:
       - checkout
-
-      - add_ssh_keys:
-          fingerprints:
-            - "f5:ca:b0:c5:06:26:aa:ec:c8:a7:75:57:f0:e7:c2:f3"
 
       - run: pwd
       - run: ls -ltra
@@ -76,7 +68,7 @@ jobs:
           aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile $AWS_PROFILE_NAME
           aws iam get-user
 
-     - run:
+      - run:
           name: Test AWS permissions
           command: aws budgets describe-budgets --account-id $AWS_ACCOUNT_ID_DEV --profile $AWS_PROFILE_NAME
 
@@ -93,10 +85,6 @@ jobs:
 
     steps:
       - checkout
-
-      - add_ssh_keys:
-          fingerprints:
-            - "f5:ca:b0:c5:06:26:aa:ec:c8:a7:75:57:f0:e7:c2:f3"
 
       - run: pwd
       - run: ls -ltra

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,8 @@ jobs:
           name: Configure awscli
           command: |
             echo "AWS_ACCESS_KEY_ID - $AWS_ACCESS_KEY_ID"
+            echo "$AWS_PROFILE_NAME - $AWS_PROFILE_NAME"
+
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID --profile $AWS_PROFILE_NAME
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile $AWS_PROFILE_NAME
             aws iam get-user
@@ -117,8 +119,10 @@ workflows:
   version: 2
   changelog_and_release:
     jobs:
-      - test-static-code-and-linting
-      - test-e2e-terratests
+      - test-static-code-and-linting:
+          context: binbashar-org-global-context
+      - test-e2e-terratests:
+          context: binbashar-org-global-context
       - release-patch-with-changelog:
           filters:
             branches:

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ terratest-go-test: ## lint: TFLint is a Terraform linter for detecting errors th
 	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} .
 
 #==============================================================#
+# CIRCLECI 													   #
+#==============================================================#
+circleci-validate-config: ## Validate A CircleCI Config (https://circleci.com/docs/2.0/local-cli/)
+	circleci config validate .circleci/config.yml
+
+#==============================================================#
 # GIT RELEASE 												   #
 #==============================================================#
 release-patch: ## releasing patch (eg: 0.0.1 -> 0.0.2) based on semantic tagging script for Git

--- a/examples/1_budget-notif-to-pre-existing-sns-specific-service-with-time-end/Makefile
+++ b/examples/1_budget-notif-to-pre-existing-sns-specific-service-with-time-end/Makefile
@@ -57,7 +57,7 @@ apply-cmd: ## Make terraform apply any changes"
 	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
-	terraform output
+	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform"
 	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}

--- a/examples/1_budget-notif-to-pre-existing-sns-specific-service-with-time-end/main.tf
+++ b/examples/1_budget-notif-to-pre-existing-sns-specific-service-with-time-end/main.tf
@@ -9,7 +9,6 @@ module "cost_mgmt_notif" {
   time_period_end      = "2019-12-31_23:59"
   cost_filters_service = "Amazon Elastic Compute Cloud - Compute"
   aws_sns_topic_arn    = "arn:aws:lambda:us-east-1:111111111111:function:bb-root-org-notify_slack"
-
 }
 
 output "sns_topic" {

--- a/examples/2_budget-notif-to-pre-existing-sns-all-services-with-time-end/Makefile
+++ b/examples/2_budget-notif-to-pre-existing-sns-all-services-with-time-end/Makefile
@@ -57,7 +57,7 @@ apply-cmd: ## Make terraform apply any changes"
 	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
-	terraform output
+	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform"
 	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}

--- a/examples/3_budget-notif-to-pre-existing-sns-specific-service/Makefile
+++ b/examples/3_budget-notif-to-pre-existing-sns-specific-service/Makefile
@@ -57,7 +57,7 @@ apply-cmd: ## Make terraform apply any changes"
 	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
-	terraform output
+	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform"
 	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}

--- a/examples/4_budget-notif-to-pre-existing-sns-all-services/Makefile
+++ b/examples/4_budget-notif-to-pre-existing-sns-all-services/Makefile
@@ -57,7 +57,7 @@ apply-cmd: ## Make terraform apply any changes"
 	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
-	terraform output
+	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform"
 	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}

--- a/examples/5_budget-notif-to-new-sns-specific-service-with-time-end/Makefile
+++ b/examples/5_budget-notif-to-new-sns-specific-service-with-time-end/Makefile
@@ -57,7 +57,7 @@ apply-cmd: ## Make terraform apply any changes"
 	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
-	terraform output
+	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform"
 	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}

--- a/examples/5_budget-notif-to-new-sns-specific-service-with-time-end/main.tf
+++ b/examples/5_budget-notif-to-new-sns-specific-service-with-time-end/main.tf
@@ -1,15 +1,14 @@
 module "cost_mgmt_notif" {
   source = "../../../terraform-aws-cost-budget"
 
-  aws_env               = "${var.aws_profile}"
-  currency              = "USD"
-  limit_amount          = 500
-  time_unit             = "MONTHLY"
-  time_period_start     = "2019-01-01_00:00"
-  time_period_end       = "2019-12-31_23:59"
-  cost_filters_service  = "Amazon Elastic Compute Cloud - Compute"
-  aws_sns_account_id    = "111111111111"
-
+  aws_env              = "${var.aws_profile}"
+  currency             = "USD"
+  limit_amount         = 500
+  time_unit            = "MONTHLY"
+  time_period_start    = "2019-01-01_00:00"
+  time_period_end      = "2019-12-31_23:59"
+  cost_filters_service = "Amazon Elastic Compute Cloud - Compute"
+  aws_sns_account_id   = "111111111111"
 }
 
 output "sns_topic" {

--- a/examples/6_budget-notif-to-new-sns-all-services-with-time-end/Makefile
+++ b/examples/6_budget-notif-to-new-sns-all-services-with-time-end/Makefile
@@ -57,7 +57,7 @@ apply-cmd: ## Make terraform apply any changes"
 	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
-	terraform output
+	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform"
 	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}

--- a/examples/6_budget-notif-to-new-sns-all-services-with-time-end/main.tf
+++ b/examples/6_budget-notif-to-new-sns-all-services-with-time-end/main.tf
@@ -1,13 +1,13 @@
 module "cost_mgmt_notif" {
   source = "../../../terraform-aws-cost-budget"
 
-  aws_env             = "${var.aws_profile}"
-  currency            = "USD"
-  limit_amount        = 500
-  time_unit           = "MONTHLY"
-  time_period_start   = "2019-01-01_00:00"
-  time_period_end     = "2019-12-31_23:59"
-  aws_sns_account_id  = "111111111111"
+  aws_env            = "${var.aws_profile}"
+  currency           = "USD"
+  limit_amount       = 500
+  time_unit          = "MONTHLY"
+  time_period_start  = "2019-01-01_00:00"
+  time_period_end    = "2019-12-31_23:59"
+  aws_sns_account_id = "111111111111"
 }
 
 output "sns_topic" {

--- a/examples/7_budget-notif-to-new-sns-specific-service/Makefile
+++ b/examples/7_budget-notif-to-new-sns-specific-service/Makefile
@@ -57,7 +57,7 @@ apply-cmd: ## Make terraform apply any changes"
 	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
-	terraform output
+	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform"
 	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}

--- a/examples/7_budget-notif-to-new-sns-specific-service/main.tf
+++ b/examples/7_budget-notif-to-new-sns-specific-service/main.tf
@@ -1,14 +1,13 @@
 module "cost_mgmt_notif" {
   source = "../../../terraform-aws-cost-budget"
 
-  aws_env               = "${var.aws_profile}"
-  currency              = "USD"
-  limit_amount          = 500
-  time_unit             = "MONTHLY"
-  time_period_start     = "2019-01-01_00:00"
-  cost_filters_service  = "Amazon Elastic Compute Cloud - Compute"
-  aws_sns_account_id    = "111111111111"
-
+  aws_env              = "${var.aws_profile}"
+  currency             = "USD"
+  limit_amount         = 500
+  time_unit            = "MONTHLY"
+  time_period_start    = "2019-01-01_00:00"
+  cost_filters_service = "Amazon Elastic Compute Cloud - Compute"
+  aws_sns_account_id   = "111111111111"
 }
 
 output "sns_topic" {

--- a/examples/8_budget-notif-to-new-sns-all-services/Makefile
+++ b/examples/8_budget-notif-to-new-sns-all-services/Makefile
@@ -57,7 +57,7 @@ apply-cmd: ## Make terraform apply any changes"
 	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
-	terraform output
+	${TF_CMD_PREFIX} output
 
 destroy: ## Destroy all resources managed by terraform"
 	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}

--- a/examples/8_budget-notif-to-new-sns-all-services/main.tf
+++ b/examples/8_budget-notif-to-new-sns-all-services/main.tf
@@ -1,13 +1,12 @@
 module "cost_mgmt_notif" {
   source = "../../../terraform-aws-cost-budget"
 
-  aws_env             = "${var.aws_profile}"
-  currency            = "USD"
-  limit_amount        = 500
-  time_unit           = "MONTHLY"
-  time_period_start   = "2019-01-01_00:00"
-  aws_sns_account_id  = "111111111111"
-
+  aws_env            = "${var.aws_profile}"
+  currency           = "USD"
+  limit_amount       = 500
+  time_unit          = "MONTHLY"
+  time_period_start  = "2019-01-01_00:00"
+  aws_sns_account_id = "111111111111"
 }
 
 output "sns_topic" {

--- a/tests/fixture/variables.tf
+++ b/tests/fixture/variables.tf
@@ -13,7 +13,7 @@ variable "region" {
 
 variable "profile" {
   description = "AWS Profile"
-  default     = "bb-dev-oaar"
+  default     = "bb-dev-deploymaster"
 }
 
 #=============================#

--- a/tests/verify_output_test.go
+++ b/tests/verify_output_test.go
@@ -1,54 +1,54 @@
 package tests
 
 import (
-	"testing"
+    "testing"
 
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/stretchr/testify/assert"
+    "github.com/gruntwork-io/terratest/modules/terraform"
+    "github.com/stretchr/testify/assert"
 )
 
 func TestAWSBudget(t *testing.T) {
-    expectedBudgetName                    := "budget-Amazon Elastic Compute Cloud - Compute-MONTHLY-dev-50-percent"
-    expectedBudgetLimitAmount             := "500.0"
-    expectedBudgetCurrency                := "USD"
-    expectedBudgetTimePeriodStart         := "2019-01-01_00:00"
-    expectedBudgetTimePeriodEnd           := "2019-12-31_23:59"
-    expectedBudgetTimeUnit				  			:= "MONTHLY"
-    expectedBudgetCostFilterService       := "Amazon Elastic Compute Cloud - Compute"
-    expectedBudgetSnsTopicArn             := "arn:aws:sns:us-east-1:523857393444:budget-billing-alarm-notification-usd-dev-50-percent"
+    expectedBudgetName                  := "budget-Amazon Elastic Compute Cloud - Compute-MONTHLY-dev-50-percent"
+    expectedBudgetLimitAmount           := "500.0"
+    expectedBudgetCurrency              := "USD"
+    expectedBudgetTimePeriodStart       := "2019-01-01_00:00"
+    expectedBudgetTimePeriodEnd         := "2019-12-31_23:59"
+    expectedBudgetTimeUnit              := "MONTHLY"
+    expectedBudgetCostFilterService     := "Amazon Elastic Compute Cloud - Compute"
+    expectedBudgetSnsTopicArn           := "arn:aws:sns:us-east-1:523857393444:budget-billing-alarm-notification-usd-dev-50-percent"
 
-	terraformOptions := &terraform.Options {
-		// The path to where our Terraform code is located
-		TerraformDir: "fixture/",
+    terraformOptions := &terraform.Options {
+        // The path to where our Terraform code is located
+        TerraformDir: "fixture/",
 
-		// Disable colors in Terraform commands so its easier to parse stdout/stderr
-		NoColor: true,
-	}
+        // Disable colors in Terraform commands so its easier to parse stdout/stderr
+        NoColor: true,
+    }
 
-	// At the end of the test, run `terraform destroy` to clean up any resources that were created
-	defer terraform.Destroy(t, terraformOptions)
+    // At the end of the test, run `terraform destroy` to clean up any resources that were created
+    defer terraform.Destroy(t, terraformOptions)
 
-	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-	terraform.InitAndApply(t, terraformOptions)
+    // This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+    terraform.InitAndApply(t, terraformOptions)
 
-	// Run `terraform output` to get the values of output variables
-	actualBudgetName              := terraform.Output(t, terraformOptions, "budget_name")
-	actualBudgetLimitAmount       := terraform.Output(t, terraformOptions, "budget_limit_amount")
-  actualBudgetCurrency          := terraform.Output(t, terraformOptions, "budeget_currency")
-  actualBudgetTimePeriodStart   := terraform.Output(t, terraformOptions, "budget_time_period_start")
-  actualBudgetTimePeriodEnd     := terraform.Output(t, terraformOptions, "budget_time_period_end")
-  actualBudgetTimeUnit          := terraform.Output(t, terraformOptions, "budget_time_unit")
-  actualBudgetCostFilterService := terraform.Output(t, terraformOptions, "budget_cost_filters_service")
-  actualBudgetSnsTopicArn       := terraform.Output(t, terraformOptions, "budget_sns_topic_arn")
+    // Run `terraform output` to get the values of output variables
+    actualBudgetName              := terraform.Output(t, terraformOptions, "budget_name")
+    actualBudgetLimitAmount       := terraform.Output(t, terraformOptions, "budget_limit_amount")
+    actualBudgetCurrency          := terraform.Output(t, terraformOptions, "budeget_currency")
+    actualBudgetTimePeriodStart   := terraform.Output(t, terraformOptions, "budget_time_period_start")
+    actualBudgetTimePeriodEnd     := terraform.Output(t, terraformOptions, "budget_time_period_end")
+    actualBudgetTimeUnit          := terraform.Output(t, terraformOptions, "budget_time_unit")
+    actualBudgetCostFilterService := terraform.Output(t, terraformOptions, "budget_cost_filters_service")
+    actualBudgetSnsTopicArn       := terraform.Output(t, terraformOptions, "budget_sns_topic_arn")
 
 
-	// Verify we're getting back the outputs we expect
-	assert.Equal(t, expectedBudgetName, actualBudgetName)
-	assert.Equal(t, expectedBudgetLimitAmount, actualBudgetLimitAmount)
-  assert.Equal(t, expectedBudgetCurrency, actualBudgetCurrency)
-  assert.Equal(t, expectedBudgetTimePeriodStart, actualBudgetTimePeriodStart)
-  assert.Equal(t, expectedBudgetTimePeriodEnd, actualBudgetTimePeriodEnd)
-  assert.Equal(t, expectedBudgetTimeUnit, actualBudgetTimeUnit)
-  assert.Equal(t, expectedBudgetCostFilterService, actualBudgetCostFilterService)
-  assert.Equal(t, expectedBudgetSnsTopicArn, actualBudgetSnsTopicArn)
+    // Verify we're getting back the outputs we expect
+    assert.Equal(t, expectedBudgetName, actualBudgetName)
+    assert.Equal(t, expectedBudgetLimitAmount, actualBudgetLimitAmount)
+    assert.Equal(t, expectedBudgetCurrency, actualBudgetCurrency)
+    assert.Equal(t, expectedBudgetTimePeriodStart, actualBudgetTimePeriodStart)
+    assert.Equal(t, expectedBudgetTimePeriodEnd, actualBudgetTimePeriodEnd)
+    assert.Equal(t, expectedBudgetTimeUnit, actualBudgetTimeUnit)
+    assert.Equal(t, expectedBudgetCostFilterService, actualBudgetCostFilterService)
+    assert.Equal(t, expectedBudgetSnsTopicArn, actualBudgetSnsTopicArn)
 }


### PR DESCRIPTION
## Updating <img src="https://avatars1.githubusercontent.com/u/31255874?s=280&v=4" alt="binbash" width="40"/> terraform-aws-cost-budget repo:

<div align="middle">
  <img src="http://automationtoolsbootcamp.com/images/terraform.png" alt="terraform" width="150"/>
  <img src="https://pbs.twimg.com/profile_images/907881675304181760/_ftIQb3v_400x400.jpg" alt="aws" width="150"/>
</div>

###  :notebook: Summary 
1. **Tests:** Static Code Analysis `terraform fmt` + Linting w/ `tflint` have been integrated with CircleCI job for automated run under PRs.
2. **Tests:** Terratests have been integrated with CircleCI job for automated run under PRs.
  
### :man_technologist:  New Commits 
- 913034f - BBL-122 updating examples
- 4c75d8f - BBL-122 go test indentation corrected
- ca676f2 - BBL-122 CircleCI static tests and terratests added - to be tested yet
- 0742cb4 - BBL-122 fixing circle job indentation error
- ba7a966 - BL-122 adding binbashar-org-global-context to circleci job
- c619552 - BBL-122 adding terratest-dep-init pre-step cmd
- c95e1d9 - BBL-122 segregating terratets steps
- c273e61 -BBL-122 updating role in tf code with deploymaster

### :triangular_flag_on_post:  Post Tasks
- Validate a new version auto-release CircleCI job result (https://circleci.com/gh/binbashar/terraform-aws-cost-budget)
- Validate all tests PASSED :heavy_check_mark: 

### :1st_place_medal:  TODO
- Add new version `1.0.0` with tf-0.12 support.