### PR TITLE
updating circleci image to ubutu 20-04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   #
   test-static-code-and-linting:
     machine:
-      image: ubuntu-1604:202007-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
+      image: ubuntu-2004:202107-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
 
       # This job has been blocked because Docker Layer Caching is not available on your plan.
       # Should upgrade if necessary.
@@ -152,7 +152,7 @@ jobs:
   #
   test-e2e-terratests:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202107-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
       docker_layer_caching: false
 
     steps:
@@ -276,7 +276,7 @@ jobs:
   #
   release-version-with-changelog:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202107-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
       docker_layer_caching: false
 
     environment:


### PR DESCRIPTION
## what
- exequielrafaela - updating circleci image to ubutu 20-04 - 112fe1a

## why
- https://app.circleci.com/pipelines/github/binbashar/terraform-aws-cost-budget/145/workflows/e2e9f5e3-7b6b-4c14-abd6-4d73e88772b5/jobs/247 

<img width="1066" alt="image" src="https://github.com/binbashar/terraform-aws-cost-budget/assets/18539704/140b0791-a359-4f53-a42f-f0958e21d1a6">


